### PR TITLE
attempt to fix prim's type exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lifeomic/prim",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Prim is a customizable TypeScript atomic styles framework for React Native.",
   "repository": "git@github.com:lifeomic/react-native-prim.git",
   "author": "LifeOmic <oss@lifeomic.com>",

--- a/src/configurePrim.tsx
+++ b/src/configurePrim.tsx
@@ -140,8 +140,8 @@ class PrimConfiguration<
       return {
         ...ssWithValuesForAttribute(this.options.spacing, attribute),
         ...ss({
-          full: { [attribute]: '100%' as const },
-          half: { [attribute]: '50%' as const },
+          ['full' as const]: { [attribute]: '100%' as const },
+          ['half' as const]: { [attribute]: '50%' as const },
         }),
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,2 @@
-import configurePrim from './configurePrim'
-import defaultOptions from './defaultOptions'
-
 export { default as configurePrim } from './configurePrim'
 export { default as defaultOptions } from './defaultOptions'
-
-export const { PrimProvider, usePrim, primmed } = configurePrim(defaultOptions)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "esnext",
-    "module": "es2015",
     "lib": ["es6", "es2016", "es2018"],
     "jsx": "react-native",
     "strict": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,8 +11,7 @@
     "noFallthroughCasesInSwitch": true,
     "forceConsistentCasingInFileNames": true,
     "moduleResolution": "node",
-    "allowSyntheticDefaultImports": true,
-    "types": ["react", "react-native"]
+    "allowSyntheticDefaultImports": true
   },
   "include": ["src/index.ts"]
 }


### PR DESCRIPTION
This PR is an unfortunate bandaid. A long-term fix may take some consideration. I could not find a workaround that would preserve a default instance of prim as a root export.

The problem I was running into is that the type declaration file was incomplete and abbreviated and therefor invalid. See this snippet from 1.1.2's `index.d.ts` file:

```typescript
                ... 77 more ...;
                blueGray900: {
                    ...;
                };
            } & {
                ...;
            };
            ... 28 more ...;
            rounded: {
                ...;
            };
        };
        readonly lg: {
            ...;
        };
        readonly xl: {
            ...;
        };
        readonly xxl: {
            ...;
        };
    } & {
        ...;
    } & Record<...>) => import("react-native").StyleProp<...>): import("react").ForwardRefExoticComponent<...> & import("hoist-non-react-statics").NonReactStatics<...>;
```

This occurs around line 159,411 😳.

Prim leverages TS's type inference, but in hindsight we can see that it's interface gets combinatorially large when lots of options are provided. Some thought will need to be given to how to compress the interface. I wasn't able to find a way to correct this with TS configuration though it may be possible to do so. 